### PR TITLE
fix: 修复app.json在windows下生成路径非法的问题

### DIFF
--- a/lib/MPXJsonGenerator.js
+++ b/lib/MPXJsonGenerator.js
@@ -32,7 +32,7 @@ module.exports = class MPXJsonGenerator extends JsonGenerator {
                             const chunk = module.getChunks()[0];
                             
                             if ( this.forceRelative ) {
-                                pages.push(path.relative(context, chunk.name));
+                                pages.push(path.posix.relative(context, chunk.name));
                             }
                             
                             else {
@@ -60,7 +60,7 @@ module.exports = class MPXJsonGenerator extends JsonGenerator {
                             const item = (list[dependency.metadata.index] || {});
                             
                             if ( this.forceRelative ) {
-                                item.pagePath = path.relative(context, chunk.name);
+                                item.pagePath = path.posix.relative(context, chunk.name);
                             }
                             
                             else {
@@ -87,7 +87,7 @@ module.exports = class MPXJsonGenerator extends JsonGenerator {
                             const chunk = module.getChunks()[0];
                             
                             if ( this.forceRelative ) {
-                                components[tagname] = path.relative(context, chunk.name);
+                                components[tagname] = path.posix.relative(context, chunk.name);
                             }
                             
                             else {


### PR DESCRIPTION
windows下生path.relative成路径为双反斜杠，会导致微信开发者工具不能识别，改为path.posix.relative